### PR TITLE
Fixed issue with output of check-diff job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -46,12 +46,25 @@ jobs:
           
           # Set hasChanges to true if there are any changed projects after filtering.
           $hasChanges = $projChanged.Length -gt 0
+          # Set singleProject to true if projChanged is not already an array of projects.
+          $singleProject = $projChanged -isnot [array]
 
           # If there are changed projects, convert to JSON array.
           if ($hasChanges)
           {
-            $projChangedJSON = ConvertTo-Json -Compress -AsArray $projChanged
+            # If only one project changed, convert to single element array.
+            if ($singleProject)
+            {
+              $projChangedJSON = ConvertTo-Json -Compress -AsArray $projChanged
+            }
+            # Else, it will already be an array.
+            else
+            {
+              $projChangedJSON = ConvertTo-Json -Compress $projChanged
+            }
           }
+          echo "project(s) changed JSON - $projChangedJSON"
+
           
           # Set output.
           echo "::set-output name=has_changes::$hasChanges"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -64,7 +64,6 @@ jobs:
             }
           }
           echo "project(s) changed JSON - $projChangedJSON"
-
           
           # Set output.
           echo "::set-output name=has_changes::$hasChanges"


### PR DESCRIPTION
## Description

The `check-diff` job originally gave output that worked in other steps for a single project.  A later change fixed it so that it worked with multiple project, but it broke the single project functionality.

This PR combines those two scenarios to determine output based on a single project being updated or multiple.

## Type of change: 2

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
