### PR TITLE
Fix Snyk monitor bug

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -89,7 +89,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args: --file=${{ needs.set_variables.outputs.package_name }}/${{ needs.set_variables.outputs.package_name }}.sln
+          args: --file=${{ needs.set_variables.outputs.package_name }}/obj/project.assets.json
 
   # publish job pushed package to NuGet.org.
   publish:


### PR DESCRIPTION
## Description

Updated Snyk monitor to use the `project.assets.json` file that should be in the same location regardless of if it is a single project repo or multi-project repo.

## Type of change: 2

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
