### PR TITLE
Remove Deprecated GitHub Actions Feature

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -118,6 +118,4 @@ jobs:
         # Getting the NUGET_API_KEY from the org secrets.
         env:
           API_KEY: ${{ secrets.NUGET_API_KEY }}
-        # run: dotnet nuget push ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg --api-key ${{ env.API_KEY }} --source https://api.nuget.org/v3/index.json
-        run: |
-          echo ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg
+        run: dotnet nuget push ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg --api-key ${{ env.API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -118,4 +118,6 @@ jobs:
         # Getting the NUGET_API_KEY from the org secrets.
         env:
           API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg --api-key ${{ env.API_KEY }} --source https://api.nuget.org/v3/index.json
+        # run: dotnet nuget push ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg --api-key ${{ env.API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: |
+          echo ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     # Creates output variables to be used in steps or other jobs.
     outputs: 
-      package_name: ${{ steps.variables.outputs.package_name }}
-      package_version: ${{ steps.variables.outputs.package_version }}
+      PACKAGE_NAME: ${{ steps.variables.outputs.PACKAGE_NAME }}
+      PACKAGE_VERSION: ${{ steps.variables.outputs.PACKAGE_VERSION }}
 
     steps:
       # Set various variables needed in other jobs.
@@ -35,16 +35,16 @@ jobs:
           # Gets package name from the release tag.
           packageName=${releaseTag%%?[[:digit:]]*}
           echo "package name: $packageName"
-          echo ::set-output name=package_name::$packageName
+          echo "PACKAGE_NAME=$packageName" >> $GITHUB_OUTPUT
 
           # Gets package version from the release tag.
           packageVersion=${releaseTag#${releaseTag%%[0-9]*}}
           echo "package version: $packageVersion"
-          echo ::set-output name=package_version::$packageVersion
+          echo "PACKAGE_VERSION=$packageVersion" >> $GITHUB_OUTPUT
 
   # build job builds for each of the target frameworks of the solution.
   build:
-    name: Build ${{ needs.set_variables.outputs.package_name }}
+    name: Build ${{ needs.set_variables.outputs.PACKAGE_NAME }}
     # This job will not run until set_variables is complete and passes.
     needs: set_variables
     # Using the latest Windows GitHub-hosted runner.
@@ -57,7 +57,7 @@ jobs:
 
       # Using dotnet build to build and package the solution.
       - name: Build
-        run: dotnet build ${{ needs.set_variables.outputs.package_name }}/${{ needs.set_variables.outputs.package_name }}.csproj --configuration Release
+        run: dotnet build ${{ needs.set_variables.outputs.PACKAGE_NAME }}/${{ needs.set_variables.outputs.PACKAGE_NAME }}.csproj --configuration Release
 
       # Using GitHub upload-artifact action to persist the workspace for the next job.
       - name: Upload workspace
@@ -89,11 +89,11 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args: --file=${{ needs.set_variables.outputs.package_name }}/obj/project.assets.json
+          args: --file=${{ needs.set_variables.outputs.PACKAGE_NAME }}/obj/project.assets.json
 
   # publish job pushed package to NuGet.org.
   publish:
-    name: Publish ${{ needs.set_variables.outputs.package_name }}
+    name: Publish ${{ needs.set_variables.outputs.PACKAGE_NAME }}
     # This job will not run until set_variables and build are complete and pass.
     needs: [ set_variables, build ]
     # Using the latest Ubuntu GitHub-hosted runner.
@@ -104,8 +104,8 @@ jobs:
   
     steps:
       # Displays the package that was approved.
-      - name: Package ${{ needs.set_variables.outputs.package_name }} approved
-        run: echo Package ${{ needs.set_variables.outputs.package_name }} approved for publishing.
+      - name: Package ${{ needs.set_variables.outputs.PACKAGE_NAME }} approved
+        run: echo Package ${{ needs.set_variables.outputs.PACKAGE_NAME }} approved for publishing.
 
       # Using GitHub download-artifact action to get the workspace from the last job.
       - name: Download workspace
@@ -114,8 +114,8 @@ jobs:
           name: workspace
 
       # Using dotnet nuget push to publish the specified package to NuGet.org.
-      - name: Publish ${{ needs.set_variables.outputs.package_name }}
+      - name: Publish ${{ needs.set_variables.outputs.PACKAGE_NAME }}
         # Getting the NUGET_API_KEY from the org secrets.
         env:
           API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push ${{ needs.set_variables.outputs.package_name }}/bin/Release/${{ needs.set_variables.outputs.package_name }}.${{ needs.set_variables.outputs.package_version }}.nupkg --api-key ${{ env.API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ${{ needs.set_variables.outputs.PACKAGE_NAME }}/bin/Release/${{ needs.set_variables.outputs.PACKAGE_NAME }}.${{ needs.set_variables.outputs.PACKAGE_VERSION }}.nupkg --api-key ${{ env.API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,11 +11,14 @@ on:
 ##  WORKFLOW JOBS
 ####################################################################################################
 jobs:
-  # build_and_test job builds and runs unit tests for each of the target frameworks of the solution.
+  # build_and_test job builds and runs unit tests, and searches for exclusions from Snyk scans.
   build_and_test:
     name: Build and test projects
     # Using the latest Windows GitHub-hosted runner.
     runs-on: windows-latest
+    # Creates output variables to be used in other jobs.
+    outputs: 
+      SNYK_EXCLUSIONS: ${{ steps.snyk-exclusions.outputs.SNYK_EXCLUSIONS }}
 
     steps:
       # Using Github checkout action to retrieve the codebase.
@@ -31,6 +34,21 @@ jobs:
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal
 
+      # Creates a comma separated list of directories or files to exclude from Snyk scans.
+      - name: Find test or example project(s) to exclude from Snyk
+        id: snyk-exclusions
+        shell: pwsh
+        run: |
+          # Filter to only Test and Example projects and add them to snykExclusions.
+          $snykExclusions = Get-ChildItem -Directory | Select-Object Name
+          $snykExclusions = $snykExclusions | Where-Object { ($_ -Match 'Tests') -or ($_ -Match 'Example') }
+          $snykExclusions = $snykExclusions | ConvertTo-CSV -UseQuotes Never -NoTypeInformation | Select-Object -Skip 1
+          $snykExclusions = $snykExclusions -join ','
+          echo "snyk exclusions - $snykExclusions"
+
+          # Set output.
+          echo "SNYK_EXCLUSIONS=$snykExclusions" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       # Using GitHub upload-artifact action to persist the workspace for the next job.
       - name: Upload workspace
         uses: actions/upload-artifact@v3
@@ -38,21 +56,14 @@ jobs:
           name: workspace
           path: ./
 
-  # Calls snyk-exclusion reusable workflow.
-  snyk_exclusions:
-    name: Snyk exclusions
-    # This job will not run until build_and_test is complete and passes.
-    needs: build_and_test
-    uses: ./.github/workflows/snyk-exclusions.yml
-
   # snyk_test job runs scan against project dependencies, looking for vulnerabilities.
   snyk_test:
     name: Snyk test
-    # This job will not run until snyk_exclusions job finishes successfully.
-    needs: snyk_exclusions
+    # This job will not run until build_and_test job finishes successfully.
+    needs: build_and_test
     # Using the latest Ubuntu GitHub-hosted runner.
     runs-on: ubuntu-latest
-    
+
     steps:
       # Using GitHub download-artifact action to get the workspace from the last job.
       - name: Download workspace
@@ -67,4 +78,4 @@ jobs:
           # Uses SNYK_TOKEN from org secrets
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --all-projects --exclude=${{ needs.snyk_exclusions.outputs.scan_exclusions }}
+          args: --all-projects --exclude=${{ needs.build_and_test.outputs.SNYK_EXCLUSIONS }}

--- a/.github/workflows/snyk-exclusions.yml
+++ b/.github/workflows/snyk-exclusions.yml
@@ -6,10 +6,6 @@ name: Snyk Exclusions
 on:
   # Workflow will run when called by another workflow.
   workflow_call:
-    # Output the list of scan exclusions to be used by the calling job.
-    outputs:
-      scan_exclusions:
-        value: ${{ jobs.snyk_exclusions.outputs.scan_exclusions }}
 
 ####################################################################################################
 ##  WORKFLOW JOBS
@@ -22,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     # Creates output variables to be used in steps or other jobs.
     outputs: 
-      scan_exclusions: ${{ steps.scan-exclusions.outputs.scan_exclusions }}
-    
+      SNYK_EXCLUSIONS: ${{ steps.snyk-exclusions.outputs.SNYK_EXCLUSIONS }}
+
     steps:
       # Using GitHub download-artifact action to get the workspace from the last job.
       - name: Download workspace
@@ -31,17 +27,17 @@ jobs:
         with:
           name: workspace
 
-    # Creates a comma separated list of directories or files to exclude from code scans.
+      # Creates a comma separated list of directories or files to exclude from code scans.
       - name: Find test or example project(s) to exclude
-        id: scan-exclusions
+        id: snyk-exclusions
         shell: pwsh
         run: |
-          # Filter to only Test and Example projects and add them to scanExclusions.
-          $scanExclusions = Get-ChildItem -Directory | Select-Object Name
-          $scanExclusions = $scanExclusions | Where-Object { ($_ -Match 'Tests') -or ($_ -Match 'Example') }
-          $scanExclusions = $scanExclusions | ConvertTo-CSV -UseQuotes Never -NoTypeInformation | Select-Object -Skip 1
-          $scanExclusions = $scanExclusions -join ','
-          echo "scan exclusions - $scanExclusions"
+          # Filter to only Test and Example projects and add them to snykExclusions.
+          $snykExclusions = Get-ChildItem -Directory | Select-Object Name
+          $snykExclusions = $snykExclusions | Where-Object { ($_ -Match 'Tests') -or ($_ -Match 'Example') }
+          $snykExclusions = $snykExclusions | ConvertTo-CSV -UseQuotes Never -NoTypeInformation | Select-Object -Skip 1
+          $snykExclusions = $snykExclusions -join ','
+          echo "snyk exclusions - $snykExclusions"
 
           # Set output.
-          echo "::set-output name=scan_exclusions::$scanExclusions"
+          echo "SNYK_EXCLUSIONS=$snykExclusions" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append


### PR DESCRIPTION
## Description

Replaced deprecated `set-output` with `GITHUB_OUTPUT`.  Using `GITHUB_OUTPUT` I was unable to get the values to persist from the `snyk-exclusions.yml` workflow so that job was moved into `build-and-test.yml`.  Due to previous changes, that workflow is only used in the `build-and-test.yml` workflow, so it no longer needs to be a separate shared workflow.

See [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for additional details on the reason for the change.

## Type of change: 1

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
