### PR TITLE
Swap Workflows To Use MSBuild

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -55,9 +55,13 @@ jobs:
       - name: Fetch code
         uses: actions/checkout@v3
 
-      # Using dotnet build to build and package the solution.
+      # Use Microsoft setup-msbuild action to add msbuild command to PATH.
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      # Using msbuild to build and package the solution.
       - name: Build
-        run: dotnet build ${{ needs.set_variables.outputs.PACKAGE_NAME }}/${{ needs.set_variables.outputs.PACKAGE_NAME }}.csproj --configuration Release
+        run: msbuild -t:build -restore -verbosity:m -property:Configuration=Release
 
       # Using GitHub upload-artifact action to persist the workspace for the next job.
       - name: Upload workspace

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,9 +22,13 @@ jobs:
       - name: Fetch code
         uses: actions/checkout@v3
 
-      # Using dotnet build to build the solution.
+      # Use Microsoft setup-msbuild action to add msbuild command to PATH.
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      # Using msbuild to build and package the solution.
       - name: Build
-        run: dotnet build --configuration Release
+        run: msbuild -t:build -restore -verbosity:m -property:Configuration=Release
 
       # Using dotnet test to run any unit tests found in the project.
       # If any test fails, the job and workflow will fail.


### PR DESCRIPTION
## Description

Switching workflows from `dotnet build` to `msbuild` as RockLib.Analyzers does not work with `dotnet build`.  This change allows all the libraries to build using the same workflow files.

Tested in RockLib.Analyzers and RockLib.Collections that the changes work.

[<img width="1137" alt="RockLib.Analyzers workflow run" src="https://user-images.githubusercontent.com/67699321/199561951-66a2601d-9a23-429a-b052-dedd499dd57a.png">](https://github.com/RockLib/RockLib.Analyzers/actions/runs/3372204990/jobs/5595359541)
[<img width="1137" alt="image" src="https://user-images.githubusercontent.com/67699321/199562289-aafa3a76-38a3-4039-993d-fadc0420e33a.png">](https://github.com/eslutz/RockLib.Collections/actions/runs/3372215026/jobs/5595381819)

<!--

1. Include a summary of the feature or issue being fixed, including relevant
   motivation and context.
2. Highlight any sections or parts that you are unsure about, and note any
   compromises you have made while developing this change.
3. Link to the corresponding issue, if one exists.

-->

## Type of change: 2

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
