### PR TITLE
added project name to snyk monitor

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -93,7 +93,8 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args: --file=${{ needs.set_variables.outputs.PACKAGE_NAME }}/obj/project.assets.json
+          args: --project-name=${{ needs.set_variables.outputs.PACKAGE_NAME }} --file=${{ needs.set_variables.outputs.PACKAGE_NAME }}/obj/project.assets.json
+
 
   # publish job pushed package to NuGet.org.
   publish:


### PR DESCRIPTION
## Description
Issue: https://git.rockfin.com/Rocket-Libraries/Planning/issues/589
Replaced ```args: --file=${{ needs.set_variables.outputs.PACKAGE_NAME }}/obj/project.assets.json``` with 

```args: --project-name=${{ needs.set_variables.outputs.PACKAGE_NAME }} --file=${{ needs.set_variables.outputs.PACKAGE_NAME }}/obj/project.assets.json```  in Snyk Monitor
<!--

1. Include a summary of the feature or issue being fixed, including relevant
   motivation and context.
2. Highlight any sections or parts that you are unsure about, and note any
   compromises you have made while developing this change.
3. Link to the corresponding issue, if one exists.

-->

